### PR TITLE
dns and production deploys

### DIFF
--- a/.buildkite/pipelines/lint.yml
+++ b/.buildkite/pipelines/lint.yml
@@ -4,8 +4,7 @@ steps:
     artifact_paths:
       - 'reports/**/*'
     command: ./scripts/lint
-    depends_on:
-      - build
+    depends_on: [ $DEPENDS_ON ]
     key: lint
     plugins:
       - ecr#v2.2.0: *plugins_ecr

--- a/.buildkite/pipelines/stack-production.yml
+++ b/.buildkite/pipelines/stack-production.yml
@@ -1,0 +1,13 @@
+steps:
+  - label: ':cloudformation: deploy (prod)'
+    <<: *step
+    agents:
+      queue: "beacon-production"
+    command: make deploy
+    depends_on: [ $DEPENDS_ON ]
+    if: "build.branch == 'master'"
+    key: sam-deploy-production
+    # This step takes a while on the first run because it has to
+    # provision/deprovision DNS records and ACM certificates. Subsequent runs
+    # should be much faster
+    timeout: 30

--- a/.buildkite/pipelines/stack-test.yml
+++ b/.buildkite/pipelines/stack-test.yml
@@ -2,8 +2,7 @@ steps:
   - label: ':cloudformation: deploy'
     <<: *step
     command: make deploy
-    depends_on:
-      - build
+    depends_on: [ $DEPENDS_ON ]
     key: sam-deploy
     # This step takes a while on the main branch because we
     # provision/deprovision DNS records and ACM certificates
@@ -13,7 +12,7 @@ steps:
     <<: *step
     allow_dependency_failure: true
     command: make destroy
-    depends_on: [ build, sam-deploy, $DESTROY_DEPENDS_ON ]
+    depends_on: [ sam-deploy, $DESTROY_DEPENDS_ON ]
     key: sam-destroy
     # This step takes a while on the main branch because we
     # provision/deprovision DNS records and ACM certificates

--- a/.buildkite/pipelines/stack.yml
+++ b/.buildkite/pipelines/stack.yml
@@ -5,6 +5,9 @@ steps:
     depends_on:
       - build
     key: sam-deploy
+    # This step takes a while on the main branch because we
+    # provision/deprovision DNS records and ACM certificates
+    timeout: 30
 
   - label: ':cloudformation: destroy'
     <<: *step
@@ -12,3 +15,6 @@ steps:
     command: make destroy
     depends_on: [ build, sam-deploy, $DESTROY_DEPENDS_ON ]
     key: sam-destroy
+    # This step takes a while on the main branch because we
+    # provision/deprovision DNS records and ACM certificates
+    timeout: 30

--- a/.buildkite/upload
+++ b/.buildkite/upload
@@ -9,12 +9,12 @@ __DIRNAME=$(dirname "$__FILENAME")
 source "$__DIRNAME/utilities"
 
 main () {
+  export STAGE_NAME='test'
+  export DEPENDS_ON='build'
+
   pipeline build.yml
   pipeline lint.yml
 
-  export STAGE_NAME='test'
-
-  export DEPENDS_ON='build'
   # Explicitly set maxWorkers; jest determines the max to be 1 which has a lot of
   # surprising side effects (like causing nock to disable the network in
   # integration tests)
@@ -31,9 +31,19 @@ main () {
     KEY=test-contract \
     pipeline test.yml
 
-  DESTROY_DEPENDS_ON='test-contract' pipeline stack.yml
+  DESTROY_DEPENDS_ON='test-contract' \
+    pipeline stack-test.yml
 
-  DEPENDS_ON="$DEPENDS_ON, lint, test-contract, test-unit" pipeline process-reports.yml
+  DEPENDS_ON="$DEPENDS_ON, lint, test-contract, test-unit" \
+    pipeline process-reports.yml
+
+  DOMAIN_NAME="beacon.codelikeacarpenter.com" \
+    DEPENDS_ON="$DEPENDS_ON, process-reports" \
+    STACK_NAME='beacon' \
+    STAGE_NAME='production' \
+    ZONE_DOMAIN_NAME="beacon.codelikeacarpenter.com" \
+    SETUP_DOMAINS=yes \
+    pipeline stack-production.yml
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/.buildkite/upload
+++ b/.buildkite/upload
@@ -12,6 +12,8 @@ main () {
   pipeline build.yml
   pipeline lint.yml
 
+  export STAGE_NAME='test'
+
   export DEPENDS_ON='build'
   # Explicitly set maxWorkers; jest determines the max to be 1 which has a lot of
   # surprising side effects (like causing nock to disable the network in

--- a/.buildkite/utilities
+++ b/.buildkite/utilities
@@ -21,25 +21,39 @@ has_buildkite_agent () {
 
 # Gets added to the top of every file sent to buildkite using pipeline()
 #
-# First, itlooks for all the environment variables matching the listed prefixes
+# First, it looks for all the environment variables matching the listed prefixes
 # and configures them to pass through to the docker container.
 #
 # Then, it loads the _header.yml file from the pipelines directory
 #
 header () {
+  local current_environment_variables=$(list_environment_variables)
+
+  local difference=$(diff  <(echo "$current_environment_variables") <(echo "$INITIAL_ENVIRONMENT_VARIABLES"))
+
+  # First, pass-through all the AWS and BUILDKITE environment variables that
+  # were set before this script ran
+  #
+  # Then, assign all the new exports that we created here.
+  #
+  # Finally, pass-through the CI variable
+  #
+  # Note that this pattern _does_ lead to setting the template vars (the ones
+  # set in the `upload` script) as environment variables, but I _think_ that
+  # should be ok.
   cat << EOT
 docker_compose_environment: &docker_compose_environment
-  - AWS_DEFAULT_REGION
-$(env | awk -F= '/^AWS_/ {print "  - " $1}')
-$(env | awk -F= '/^BUILDKITE/ {print "  - " $1}')
-$(env | awk -F= '/^CHECK_RUN_REPORTER_/ {print "  - " $1 "=$" $1}')
-$(env | awk -F= '/^CI_/ {print "  - " $1 "=$" $1}')
-$(env | awk -F= '/^SAM_/ {print "  - " $1 "=$" $1}')
+$(echo "$INITIAL_ENVIRONMENT_VARIABLES" | awk '/^AWS_/ {print "  - " $1}')
+$(echo "$INITIAL_ENVIRONMENT_VARIABLES" | awk '/^BUILDKITE/ {print "  - " $1}')
+$(echo "$difference" | awk '/^</ {print "  - " $2 "=$" $2}')
   - CI
-  - DEBUG
 
 $(template < "$__DIRNAME/pipelines/_header.yml")
 EOT
+}
+
+list_environment_variables () {
+  env | awk -F= '{print $1}' | grep -v '^_' | sort
 }
 
 # Public: Echos to stderr instead of stdout to avoid polluting the pipeline yml
@@ -107,6 +121,8 @@ upload () {
 }
 
 init_utilities () {
+  INITIAL_ENVIRONMENT_VARIABLES=$(list_environment_variables)
+
   export CHECK_RUN_REPORTER_REPO_TOKEN='1a626bae-dbc9-4f82-9848-f71dd5be9ae6'
 
   # Turn off spyware

--- a/.buildkite/utilities
+++ b/.buildkite/utilities
@@ -166,6 +166,10 @@ init_utilities () {
   # stacks in the CloudFormation UI.
   export CI_STACK_NAME
   CI_STACK_NAME=ci--$BUILDKITE_PIPELINE_NAME--$CI_SAFE_BRANCH_NAME--$BUILDKITE_COMMIT
+
+  local SHORT_SHA=${BUILDKITE_COMMIT:0:10}
+  export DOMAIN_NAME="$SHORT_SHA.test.beacon.codelikeacarpenter.com"
+  export ZONE_DOMAIN_NAME=test.beacon.codelikeacarpenter.com
 }
 
 set_local_defaults () {

--- a/.buildkite/utilities
+++ b/.buildkite/utilities
@@ -167,6 +167,12 @@ init_utilities () {
   export CI_STACK_NAME
   CI_STACK_NAME=ci--$BUILDKITE_PIPELINE_NAME--$CI_SAFE_BRANCH_NAME--$BUILDKITE_COMMIT
 
+  # Only setup domains on the main branch since it adds _a lot_ of time to the
+  # stack deploy process. We'll test against real domains before a production
+  # deployment, but we'll try to keep PR build time reasonable.
+  if [ "$BUILDKITE_BRANCH" != "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]; then
+    export SKIP_DOMAIN_SETUP=yes
+  fi
   local SHORT_SHA=${BUILDKITE_COMMIT:0:10}
   export DOMAIN_NAME="$SHORT_SHA.test.beacon.codelikeacarpenter.com"
   export ZONE_DOMAIN_NAME=test.beacon.codelikeacarpenter.com

--- a/.buildkite/utilities
+++ b/.buildkite/utilities
@@ -90,6 +90,15 @@ EOT
 upload () {
   local pipeline="$1"
 
+  # Only do this in CI so we don't end up with a rogue file when running
+  # locally. Locally, we'll print to stdout, so we can write to file if needed.
+  if [ -n "${CI:-}" ]; then
+    # Make sure pipeline.generated.yml
+    touch pipeline.generated.yml
+    # Append to pipeline.generated.yml so that the job export it as an artifact.
+    echo "$pipeline" >> pipeline.generated.yml
+  fi
+
   if has_buildkite_agent; then
     echo "$pipeline" | buildkite-agent pipeline upload
   else

--- a/.buildkite/utilities
+++ b/.buildkite/utilities
@@ -171,7 +171,7 @@ init_utilities () {
   # stack deploy process. We'll test against real domains before a production
   # deployment, but we'll try to keep PR build time reasonable.
   if [ "$BUILDKITE_BRANCH" != "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]; then
-    export SKIP_DOMAIN_SETUP=yes
+    export SETUP_DOMAINS=no
   fi
   local SHORT_SHA=${BUILDKITE_COMMIT:0:10}
   export DOMAIN_NAME="$SHORT_SHA.test.beacon.codelikeacarpenter.com"

--- a/.buildkite/utilities
+++ b/.buildkite/utilities
@@ -1,58 +1,19 @@
 #!/usr/bin/env bash
 
-export CHECK_RUN_REPORTER_REPO_TOKEN='1a626bae-dbc9-4f82-9848-f71dd5be9ae6'
+compute_docker_safe_branch_name () {
+  local branch_name="$1"
 
-# Make sure that __DIRNAME is the fully qualified path to the directory where
-# this script is located.
-__DIRNAME=${__DIRNAME:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}
+  # Docker tags cannot includes slashes
+  branch_name=${branch_name//\//-}
+  # Docker tags cannot includes @ signs
+  branch_name=${branch_name/@/-}
+  # Stack names cannot includes underscores
+  branch_name=${branch_name//_/-}
+  # Stack names cannot includes periods
+  branch_name=${branch_name//\./-}
 
-# If not running in CI, use local values and/or fallbacks so that we can print
-# the output from the command line for debugging.
-if [ -z "${CI:-}" ]; then
-  BUILDKITE_BRANCH=${BUILDKITE_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
-  BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:-fake_repository_name}
-  BUILDKITE_PIPELINE_DEFAULT_BRANCH=${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-main}
-  BUILDKITE_PIPELINE_NAME=${BUILDKITE_PIPELINE_NAME:-fake_pipeline_name}
-  BUILDKITE_COMMIT=${BUILDKITE_COMMIT:-$(git rev-parse HEAD)}
-fi
-
-# Docker tags cannot includes slashes
-CI_SAFE_BRANCH_NAME=${BUILDKITE_BRANCH//\//-}
-# Docker tags cannot includes @ signs
-CI_SAFE_BRANCH_NAME=${CI_SAFE_BRANCH_NAME/@/-}
-# Stack names cannot includes underscores
-CI_SAFE_BRANCH_NAME=${CI_SAFE_BRANCH_NAME//_/-}
-# Stack names cannot includes periods
-CI_SAFE_BRANCH_NAME=${CI_SAFE_BRANCH_NAME//\./-}
-
-# The ECR repository name of the main branch Docker image
-export CI_DOCKER_COMPOSE_IMAGE_MAIN_TAG
-CI_DOCKER_COMPOSE_IMAGE_MAIN_TAG="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_DEFAULT_BRANCH"
-
-# The ECR repository name of current branch Docker image
-export CI_DOCKER_COMPOSE_IMAGE_BRANCH_TAG
-CI_DOCKER_COMPOSE_IMAGE_BRANCH_TAG="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:$CI_SAFE_BRANCH_NAME"
-
-export CI_STACK_PREFIX
-CI_STACK_PREFIX=ci--$CI_SAFE_BRANCH_NAME
-
-# The name of the CloudFormation stack that'll be deployed for testing. It needs
-# to be unique to so that other jobs don't collide with it and so that, if
-# someone pushes a new commit for this branch when 1. the stack failed to deploy
-# and 2. the stack was not cleaned up, the next job won't fail because the stack
-# is in an unrecoverable state. While the commit is probably enough to guarantee
-# that uniqueness, having the branch makes it much easier to interpret the
-# stacks in the CloudFormation UI.
-export CI_STACK_NAME
-CI_STACK_NAME=ci--$BUILDKITE_PIPELINE_NAME--$CI_SAFE_BRANCH_NAME--$BUILDKITE_COMMIT
-
-# Turn off spyware
-export SAM_CLI_TELEMETRY
-SAM_CLI_TELEMETRY=0
-
-# Print debug logs from the axios client used by the Check Run Reporter plugin
-export DEBUG
-DEBUG=axios
+  echo $branch_name
+}
 
 has_buildkite_agent () {
   command -v buildkite-agent > /dev/null 2>&1
@@ -136,6 +97,60 @@ upload () {
   fi
 }
 
+init_utilities () {
+  export CHECK_RUN_REPORTER_REPO_TOKEN='1a626bae-dbc9-4f82-9848-f71dd5be9ae6'
+
+  # Turn off spyware
+  export SAM_CLI_TELEMETRY
+  SAM_CLI_TELEMETRY=0
+
+  # Print debug logs from the axios client used by the Check Run Reporter plugin
+  export DEBUG
+  DEBUG=axios
+
+  # Make sure that __DIRNAME is the fully qualified path to the directory where
+  # this script is located.
+  __DIRNAME=${__DIRNAME:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}
+
+  # If not running in CI, use local values and/or fallbacks so that we can print
+  # the output from the command line for debugging.
+  if [ -z "${CI:-}" ]; then
+    log "This does not appear to be a CI build. Setting defaults for local execution"
+    set_local_defaults
+  fi
+
+  CI_SAFE_BRANCH_NAME="$(compute_docker_safe_branch_name $BUILDKITE_BRANCH)"
+
+  # The ECR repository name of the main branch Docker image
+  export CI_DOCKER_COMPOSE_IMAGE_MAIN_TAG
+  CI_DOCKER_COMPOSE_IMAGE_MAIN_TAG="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:$BUILDKITE_PIPELINE_DEFAULT_BRANCH"
+
+  # The ECR repository name of current branch Docker image
+  export CI_DOCKER_COMPOSE_IMAGE_BRANCH_TAG
+  CI_DOCKER_COMPOSE_IMAGE_BRANCH_TAG="$BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:$CI_SAFE_BRANCH_NAME"
+
+  export CI_STACK_PREFIX
+  CI_STACK_PREFIX=ci--$CI_SAFE_BRANCH_NAME
+
+  # The name of the CloudFormation stack that'll be deployed for testing. It needs
+  # to be unique to so that other jobs don't collide with it and so that, if
+  # someone pushes a new commit for this branch when 1. the stack failed to deploy
+  # and 2. the stack was not cleaned up, the next job won't fail because the stack
+  # is in an unrecoverable state. While the commit is probably enough to guarantee
+  # that uniqueness, having the branch makes it much easier to interpret the
+  # stacks in the CloudFormation UI.
+  export CI_STACK_NAME
+  CI_STACK_NAME=ci--$BUILDKITE_PIPELINE_NAME--$CI_SAFE_BRANCH_NAME--$BUILDKITE_COMMIT
+}
+
+set_local_defaults () {
+  BUILDKITE_BRANCH=${BUILDKITE_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY=${BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY:-fake_repository_name}
+  BUILDKITE_PIPELINE_DEFAULT_BRANCH=${BUILDKITE_PIPELINE_DEFAULT_BRANCH:-main}
+  BUILDKITE_PIPELINE_NAME=${BUILDKITE_PIPELINE_NAME:-fake_pipeline_name}
+  BUILDKITE_COMMIT=${BUILDKITE_COMMIT:-$(git rev-parse HEAD)}
+}
+
 # Public: Substitutes environment variables into stdin
 #
 # Examples
@@ -161,3 +176,5 @@ template () {
     return 1
   fi
 }
+
+init_utilities

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ compute_deps_for_package = $(shell $(CLI) compute-deps-for-package $(1))
 
 PACKAGES_DIR             := packages
 SENTINEL_DIR             := .tmp/sentinel
-SAM_CONFIG_ENV           ?= default
 CHAMBER                  ?= beacon
 
 PACKAGES                  := $(subst $(PACKAGES_DIR)/,,$(wildcard $(PACKAGES_DIR)/*/*))

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,9 @@ dependencies/nodejs/package-lock.json: dependencies/nodejs/package.json
 
 dredd.yml: dredd.yml.tpl cloudformation/config.toml scripts/Makefile/dredd
 	scripts/Makefile/dredd $< > $@
+	mkdir -p reports/config
+	cp $@ reports/config/$@
+
 
 packages/@beacon/gateway-schema/src/__generated__/index.ts: cloudformation/api.yml
 	$(NPX) openapi-typescript $< --prettier-config ./.prettierrc --output $@

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -2,15 +2,6 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 
 Parameters:
-  SkipDomainSetup:
-    Type: String
-    Default: AWS::NoValue
-    Description: |
-      Provides an escape hatch to skip domain setup. Domain resources are slow
-      to set up (and even slower to destroy), so they make PR builds very slow,
-      but it's still a good idea to run domain builds on the main branch before
-      a production deploy.
-
   DomainName:
     Type: String
     Default: AWS::NoValue
@@ -25,6 +16,15 @@ Parameters:
 
   HostedZoneId:
     Type: String
+
+  SetupDomains:
+    Type: String
+    Default: 'yes'
+    Description: |
+      Provides an escape hatch to skip domain setup. Domain resources are slow
+      to set up (and even slower to destroy), so they make PR builds very slow,
+      but it's still a good idea to run domain builds on the main branch before
+      a production deploy.
 
   StageName:
     Type: String
@@ -53,8 +53,8 @@ Conditions:
     - development
 
   ConfigureDomains: !Equals
-    - !Ref SkipDomainSetup
-    - AWS::NoValue
+    - !Ref SetupDomains
+    - 'yes'
 
 Globals:
   Function:

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -4,12 +4,17 @@ Transform: 'AWS::Serverless-2016-10-31'
 Parameters:
   DomainName:
     Type: String
-    Default: 'playground.beacon.codelikeacarpenter.com'
+    Description: |
+      The base domain name for the stack's application. There should already be
+      a matching Route53 Hosted Zone in this account matching this domain.
 
   LogRetention:
     Type: Number
     Default: '3'
     Description: Duration in days to retain logs
+
+  HostedZoneId:
+    Type: String
 
   StageName:
     Type: String
@@ -36,11 +41,6 @@ Conditions:
   IsDev: !Equals
     - !Ref StageName
     - development
-
-  IsNotTest: !Not
-    - !Equals
-      - !Ref StageName
-      - test
 
 Globals:
   Function:
@@ -127,49 +127,90 @@ Resources:
   # DNS
   ##############################################################################
 
-  # I don't really like this setup, but I haven't found a better way to make it
-  # work. This assume that development, test, and prod are all separate accounts
-  # and that that root domain (and its hosted zone) are managed by a fourth
+  # In addition to the following DNS config, HostedZones need to be created
+  # outside of CloudFormation. CF doesn't practically support managing resources
+  # in more than one account,
+  #
+  # The following terraform is one way to create those zones
+  #
+  # ```tf
+  # data "aws_route53_zone" "codelikeacarpenter" {
+  #  name = "codelikeacarpenter.com"
+  # }
+  #
+  # resource "aws_route53_zone" "beacon_production" {
+  #   provider = aws.beacon_production
+  #   name     = "beacon.codelikeacarpenter.com"
+  # }
+  #
+  # resource "aws_route53_record" "beacon_production" {
+  #   zone_id = data.aws_route53_zone.codelikeacarpenter.zone_id
+  #   name    = "beacon.codelikeacarpenter.com"
+  #   type    = "NS"
+  #   # Once this all seems to be working, this should be something more like
+  #   # one day instead of five minutes.
+  #   ttl     = "300"
+  #   records = aws_route53_zone.beacon_production.name_servers
+  # }
+  #
+  # resource "aws_route53_zone" "beacon_ci" {
+  #   provider = aws.ci
+  #   name     = "test.beacon.codelikeacarpenter.com"
+  # }
+  #
+  # resource "aws_route53_record" "beacon_ci" {
+  #   zone_id = data.aws_route53_zone.codelikeacarpenter.zone_id
+  #   name    = "test.beacon.codelikeacarpenter.com"
+  #   type    = "NS"
+  #   # This needs more investigation, but the development and test stacks may
+  #   # deploy significantly faster if this ttl is made much lower.
+  #   ttl     = "300"
+  #   records = aws_route53_zone.beacon_ci.name_servers
+  # }
+  #
+  # resource "aws_route53_zone" "beacon_playground" {
+  #   provider = aws.playground
+  #   name     = "playground.beacon.codelikeacarpenter.com"
+  # }
+  #
+  # resource "aws_route53_record" "beacon_playground" {
+  #   zone_id = data.aws_route53_zone.codelikeacarpenter.zone_id
+  #   name    = "playground.beacon.codelikeacarpenter.com"
+  #   type    = "NS"
+  #   # This needs more investigation, but the development and test stacks may
+  #   # deploy significantly faster if this ttl is made much lower.
+  #   ttl     = "300"
+  #   records = aws_route53_zone.beacon_playground.name_servers
+  # }
+  # ```
+  #
+  # This setup seems to address most of the issues of the previous setup.
+  # 1. The zones are persistent and managed outside of CloudFormation, so
+  # there's no need for the manual step of setting up NS records.
+  # 2. There's still an issue if we want to mount this application at the root
+  # of a domain, but that's now an issue to solve externally. For example,
+  # assuming the domain is registered in the management account, but that we're
+  # to serve prod out of a dedicated account, we can use pretty much the same
+  # terraform config as above, but instead of
+  # `data.aws_route53_zone.codelikeacarpenter`, we can use
+  # `aws_route53domains_registered_domain` to delegate the root domain's zone
+  # to the production account, and then use the rest of the resourse to
+  # that zone instead of the mgmt account's root zone. I won't be doing that
+  # here since I don't want to host codelikeacarpenter.com in the beacon prod
   # account
-  # Problem #1: Stack Update will be stuck until Zone's name servers are entered
-  # into the hosted zone for the main domain. Something like
-  # !Ref DomainName NS ${NameServers}
-  # Unfortunately, there's no way to automate that without a separate stack, a
-  # far more complex build pipeline, and (probably) a bunch of aws cli calls to
-  # interrogate Zone's name servers.
-  # Problem #2: If this were being deployed to a top level domain, it wouldn't
-  # work. There doesn't appear to be anyway to delegate a top-level domain, so
-  # the prod account would have to do the delegation to the other accounts. Such
-  # a setup might actually let us put nearly everything into this cloudformation
-  # template, but it would still be tedious. For one, we'd need to do a few
-  # deployment passes. First, we'd need to just create Zone's in each account.
-  # Then, we'd need to come up with a way for the prod deployment job to find
-  # out the name servers for the other accounts. The we could add the delegation
-  # records to the prod account. Finally,  we could add in the rest of the
-  # resources.
-  # Problem #3: Since we need a way to communicate the Zone's name servers to
-  # the management account, we can't actually run any of this in test. For
-  # something like this to work in test, we'd need to create a permanent Zone
-  # in the test account using CloudFormation or terraform.
-
-  Zone:
-    Type: AWS::Route53::HostedZone
-    Condition: IsNotTest
-    Properties:
-      Name: !Ref DomainName
+  # 3. Now that all the zones are persistent, we can use this setup during tests
 
   Certificate:
     Type: AWS::CertificateManager::Certificate
-    Condition: IsNotTest
     Properties:
       DomainName: !Ref DomainName
       DomainValidationOptions:
         - DomainName: !Ref DomainName
-          HostedZoneId: !Ref Zone
+          HostedZoneId: !Ref HostedZoneId
         - DomainName: !Sub "api.${DomainName}"
-          HostedZoneId: !Ref Zone
+          HostedZoneId: !Ref HostedZoneId
         - DomainName: !Sub "www.${DomainName}"
-          HostedZoneId: !Ref Zone
+          HostedZoneId: !Ref HostedZoneId
       SubjectAlternativeNames:
         - !Sub "api.${DomainName}"
         - !Sub "www.${DomainName}"
@@ -177,7 +218,6 @@ Resources:
 
   ApiDomainName:
     Type: AWS::ApiGateway::DomainName
-    Condition: IsNotTest
     Properties:
       CertificateArn: !Ref Certificate
       DomainName: !Sub 'api.${DomainName}'
@@ -187,7 +227,6 @@ Resources:
 
   ApiBasePathMapping:
     Type: 'AWS::ApiGateway::BasePathMapping'
-    Condition: IsNotTest
     Properties:
       DomainName: !Ref ApiDomainName
       RestApiId: !Ref Api
@@ -195,9 +234,8 @@ Resources:
 
   ApiRoute53RecordSetGroup:
     Type: AWS::Route53::RecordSetGroup
-    Condition: IsNotTest
     Properties:
-      HostedZoneId: !Ref Zone
+      HostedZoneId: !Ref HostedZoneId
       RecordSets:
         - Name: !Sub 'api.${DomainName}'
           Type: A
@@ -212,7 +250,6 @@ Resources:
 
   RootDomainName:
     Type: AWS::ApiGateway::DomainName
-    Condition: IsNotTest
     Properties:
       CertificateArn: !Ref Certificate
       DomainName: !Ref DomainName
@@ -222,7 +259,6 @@ Resources:
 
   RootBasePathMapping:
     Type: 'AWS::ApiGateway::BasePathMapping'
-    Condition: IsNotTest
     Properties:
       DomainName: !Ref RootDomainName
       RestApiId: !Ref Api
@@ -230,9 +266,8 @@ Resources:
 
   RootRoute53RecordSetGroup:
     Type: AWS::Route53::RecordSetGroup
-    Condition: IsNotTest
     Properties:
-      HostedZoneId: !Ref Zone
+      HostedZoneId: !Ref HostedZoneId
       RecordSets:
         - Name: !Sub '${DomainName}'
           Type: A
@@ -247,7 +282,6 @@ Resources:
 
   WwwDomainName:
     Type: AWS::ApiGateway::DomainName
-    Condition: IsNotTest
     Properties:
       CertificateArn: !Ref Certificate
       DomainName: !Sub 'www.${DomainName}'
@@ -257,7 +291,6 @@ Resources:
 
   WwwBasePathMapping:
     Type: 'AWS::ApiGateway::BasePathMapping'
-    Condition: IsNotTest
     Properties:
       DomainName: !Ref WwwDomainName
       RestApiId: !Ref Api
@@ -265,9 +298,8 @@ Resources:
 
   WwwRoute53RecordSetGroup:
     Type: AWS::Route53::RecordSetGroup
-    Condition: IsNotTest
     Properties:
-      HostedZoneId: !Ref Zone
+      HostedZoneId: !Ref HostedZoneId
       RecordSets:
         - Name: !Sub 'www.${DomainName}'
           Type: A

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -2,6 +2,10 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 
 Parameters:
+  DomainName:
+    Type: String
+    Default: 'playground.beacon.codelikeacarpenter.com'
+
   LogRetention:
     Type: Number
     Default: '3'
@@ -32,6 +36,11 @@ Conditions:
   IsDev: !Equals
     - !Ref StageName
     - development
+
+  IsNotTest: !Not
+    - !Equals
+      - !Ref StageName
+      - test
 
 Globals:
   Function:
@@ -113,6 +122,163 @@ Resources:
       # Need to include the stack name because layer names are global.
       LayerName: !Sub dependencies-${AWS::StackName}
       RetentionPolicy: Delete
+
+  ##############################################################################
+  # DNS
+  ##############################################################################
+
+  # I don't really like this setup, but I haven't found a better way to make it
+  # work. This assume that development, test, and prod are all separate accounts
+  # and that that root domain (and its hosted zone) are managed by a fourth
+  # account
+  # Problem #1: Stack Update will be stuck until Zone's name servers are entered
+  # into the hosted zone for the main domain. Something like
+  # !Ref DomainName NS ${NameServers}
+  # Unfortunately, there's no way to automate that without a separate stack, a
+  # far more complex build pipeline, and (probably) a bunch of aws cli calls to
+  # interrogate Zone's name servers.
+  # Problem #2: If this were being deployed to a top level domain, it wouldn't
+  # work. There doesn't appear to be anyway to delegate a top-level domain, so
+  # the prod account would have to do the delegation to the other accounts. Such
+  # a setup might actually let us put nearly everything into this cloudformation
+  # template, but it would still be tedious. For one, we'd need to do a few
+  # deployment passes. First, we'd need to just create Zone's in each account.
+  # Then, we'd need to come up with a way for the prod deployment job to find
+  # out the name servers for the other accounts. The we could add the delegation
+  # records to the prod account. Finally,  we could add in the rest of the
+  # resources.
+  # Problem #3: Since we need a way to communicate the Zone's name servers to
+  # the management account, we can't actually run any of this in test. For
+  # something like this to work in test, we'd need to create a permanent Zone
+  # in the test account using CloudFormation or terraform.
+
+  Zone:
+    Type: AWS::Route53::HostedZone
+    Condition: IsNotTest
+    Properties:
+      Name: !Ref DomainName
+
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Condition: IsNotTest
+    Properties:
+      DomainName: !Ref DomainName
+      DomainValidationOptions:
+        - DomainName: !Ref DomainName
+          HostedZoneId: !Ref Zone
+        - DomainName: !Sub "api.${DomainName}"
+          HostedZoneId: !Ref Zone
+        - DomainName: !Sub "www.${DomainName}"
+          HostedZoneId: !Ref Zone
+      SubjectAlternativeNames:
+        - !Sub "api.${DomainName}"
+        - !Sub "www.${DomainName}"
+      ValidationMethod: DNS
+
+  ApiDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Condition: IsNotTest
+    Properties:
+      CertificateArn: !Ref Certificate
+      DomainName: !Sub 'api.${DomainName}'
+      EndpointConfiguration:
+        Types:
+          - EDGE
+
+  ApiBasePathMapping:
+    Type: 'AWS::ApiGateway::BasePathMapping'
+    Condition: IsNotTest
+    Properties:
+      DomainName: !Ref ApiDomainName
+      RestApiId: !Ref Api
+      Stage: !Ref Api.Stage
+
+  ApiRoute53RecordSetGroup:
+    Type: AWS::Route53::RecordSetGroup
+    Condition: IsNotTest
+    Properties:
+      HostedZoneId: !Ref Zone
+      RecordSets:
+        - Name: !Sub 'api.${DomainName}'
+          Type: A
+          AliasTarget:
+            HostedZoneId: !GetAtt ApiDomainName.DistributionHostedZoneId
+            DNSName: !GetAtt ApiDomainName.DistributionDomainName
+        - Name: !Sub 'api.${DomainName}'
+          Type: AAAA
+          AliasTarget:
+            HostedZoneId: !GetAtt ApiDomainName.DistributionHostedZoneId
+            DNSName: !GetAtt ApiDomainName.DistributionDomainName
+
+  RootDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Condition: IsNotTest
+    Properties:
+      CertificateArn: !Ref Certificate
+      DomainName: !Ref DomainName
+      EndpointConfiguration:
+        Types:
+          - EDGE
+
+  RootBasePathMapping:
+    Type: 'AWS::ApiGateway::BasePathMapping'
+    Condition: IsNotTest
+    Properties:
+      DomainName: !Ref RootDomainName
+      RestApiId: !Ref Api
+      Stage: !Ref Api.Stage
+
+  RootRoute53RecordSetGroup:
+    Type: AWS::Route53::RecordSetGroup
+    Condition: IsNotTest
+    Properties:
+      HostedZoneId: !Ref Zone
+      RecordSets:
+        - Name: !Sub '${DomainName}'
+          Type: A
+          AliasTarget:
+            HostedZoneId: !GetAtt RootDomainName.DistributionHostedZoneId
+            DNSName: !GetAtt RootDomainName.DistributionDomainName
+        - Name: !Sub '${DomainName}'
+          Type: AAAA
+          AliasTarget:
+            HostedZoneId: !GetAtt RootDomainName.DistributionHostedZoneId
+            DNSName: !GetAtt RootDomainName.DistributionDomainName
+
+  WwwDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Condition: IsNotTest
+    Properties:
+      CertificateArn: !Ref Certificate
+      DomainName: !Sub 'www.${DomainName}'
+      EndpointConfiguration:
+        Types:
+          - EDGE
+
+  WwwBasePathMapping:
+    Type: 'AWS::ApiGateway::BasePathMapping'
+    Condition: IsNotTest
+    Properties:
+      DomainName: !Ref WwwDomainName
+      RestApiId: !Ref Api
+      Stage: !Ref Api.Stage
+
+  WwwRoute53RecordSetGroup:
+    Type: AWS::Route53::RecordSetGroup
+    Condition: IsNotTest
+    Properties:
+      HostedZoneId: !Ref Zone
+      RecordSets:
+        - Name: !Sub 'www.${DomainName}'
+          Type: A
+          AliasTarget:
+            HostedZoneId: !GetAtt WwwDomainName.DistributionHostedZoneId
+            DNSName: !GetAtt WwwDomainName.DistributionDomainName
+        - Name: !Sub 'www.${DomainName}'
+          Type: AAAA
+          AliasTarget:
+            HostedZoneId: !GetAtt WwwDomainName.DistributionHostedZoneId
+            DNSName: !GetAtt WwwDomainName.DistributionDomainName
 
   ##############################################################################
   # Endpoint Lambdas

--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -2,8 +2,18 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 
 Parameters:
+  SkipDomainSetup:
+    Type: String
+    Default: AWS::NoValue
+    Description: |
+      Provides an escape hatch to skip domain setup. Domain resources are slow
+      to set up (and even slower to destroy), so they make PR builds very slow,
+      but it's still a good idea to run domain builds on the main branch before
+      a production deploy.
+
   DomainName:
     Type: String
+    Default: AWS::NoValue
     Description: |
       The base domain name for the stack's application. There should already be
       a matching Route53 Hosted Zone in this account matching this domain.
@@ -41,6 +51,10 @@ Conditions:
   IsDev: !Equals
     - !Ref StageName
     - development
+
+  ConfigureDomains: !Equals
+    - !Ref SkipDomainSetup
+    - AWS::NoValue
 
 Globals:
   Function:
@@ -202,6 +216,7 @@ Resources:
 
   Certificate:
     Type: AWS::CertificateManager::Certificate
+    Condition: ConfigureDomains
     Properties:
       DomainName: !Ref DomainName
       DomainValidationOptions:
@@ -218,6 +233,7 @@ Resources:
 
   ApiDomainName:
     Type: AWS::ApiGateway::DomainName
+    Condition: ConfigureDomains
     Properties:
       CertificateArn: !Ref Certificate
       DomainName: !Sub 'api.${DomainName}'
@@ -227,6 +243,7 @@ Resources:
 
   ApiBasePathMapping:
     Type: 'AWS::ApiGateway::BasePathMapping'
+    Condition: ConfigureDomains
     Properties:
       DomainName: !Ref ApiDomainName
       RestApiId: !Ref Api
@@ -234,6 +251,7 @@ Resources:
 
   ApiRoute53RecordSetGroup:
     Type: AWS::Route53::RecordSetGroup
+    Condition: ConfigureDomains
     Properties:
       HostedZoneId: !Ref HostedZoneId
       RecordSets:
@@ -250,6 +268,7 @@ Resources:
 
   RootDomainName:
     Type: AWS::ApiGateway::DomainName
+    Condition: ConfigureDomains
     Properties:
       CertificateArn: !Ref Certificate
       DomainName: !Ref DomainName
@@ -259,6 +278,7 @@ Resources:
 
   RootBasePathMapping:
     Type: 'AWS::ApiGateway::BasePathMapping'
+    Condition: ConfigureDomains
     Properties:
       DomainName: !Ref RootDomainName
       RestApiId: !Ref Api
@@ -266,6 +286,7 @@ Resources:
 
   RootRoute53RecordSetGroup:
     Type: AWS::Route53::RecordSetGroup
+    Condition: ConfigureDomains
     Properties:
       HostedZoneId: !Ref HostedZoneId
       RecordSets:
@@ -282,6 +303,7 @@ Resources:
 
   WwwDomainName:
     Type: AWS::ApiGateway::DomainName
+    Condition: ConfigureDomains
     Properties:
       CertificateArn: !Ref Certificate
       DomainName: !Sub 'www.${DomainName}'
@@ -291,6 +313,7 @@ Resources:
 
   WwwBasePathMapping:
     Type: 'AWS::ApiGateway::BasePathMapping'
+    Condition: ConfigureDomains
     Properties:
       DomainName: !Ref WwwDomainName
       RestApiId: !Ref Api
@@ -298,6 +321,7 @@ Resources:
 
   WwwRoute53RecordSetGroup:
     Type: AWS::Route53::RecordSetGroup
+    Condition: ConfigureDomains
     Properties:
       HostedZoneId: !Ref HostedZoneId
       RecordSets:

--- a/scripts/Makefile/dredd
+++ b/scripts/Makefile/dredd
@@ -13,7 +13,11 @@ else
   STACK_NAME=$(toml_to_json cloudformation/config.toml | jq -r .default.global.parameters.stack_name)
 fi
 
-ENDPOINT=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ApiUrl") | .OutputValue')
+if [ -n "${DOMAIN_NAME:-}" ]; then
+  ENDPOINT="https://$DOMAIN_NAME"
+else
+  ENDPOINT=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ApiUrl") | .OutputValue')
+fi
 
 OUT=$(sed -e "s#endpoint.*#endpoint: $ENDPOINT#" dredd.yml.tpl)
 if [ -n "${BUILDKITE_JOB_ID:-}" ]; then

--- a/scripts/Makefile/dredd
+++ b/scripts/Makefile/dredd
@@ -13,7 +13,7 @@ else
   STACK_NAME=$(toml_to_json cloudformation/config.toml | jq -r .default.global.parameters.stack_name)
 fi
 
-if [ -n "${DOMAIN_NAME:-}" ] && [ -z "${SKIP_DOMAIN_SETUP:-}" ]; then
+if [ -n "${DOMAIN_NAME:-}" ] && [ "${SETUP_DOMAINS:-}" == 'yes' ]; then
   ENDPOINT="https://$DOMAIN_NAME"
 else
   ENDPOINT=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ApiUrl") | .OutputValue')

--- a/scripts/Makefile/dredd
+++ b/scripts/Makefile/dredd
@@ -13,7 +13,7 @@ else
   STACK_NAME=$(toml_to_json cloudformation/config.toml | jq -r .default.global.parameters.stack_name)
 fi
 
-if [ -n "${DOMAIN_NAME:-}" ]; then
+if [ -n "${DOMAIN_NAME:-}" ] && [ -z "${SKIP_DOMAIN_SETUP:-}" ]; then
   ENDPOINT="https://$DOMAIN_NAME"
 else
   ENDPOINT=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "ApiUrl") | .OutputValue')

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -38,11 +38,7 @@ PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=SHA,ParameterValue=$SHA}"
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=XHoneycombTeam,ParameterValue=$X_HONEYCOMB_TEAM"
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=DomainName,ParameterValue=$DOMAIN_NAME"
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=HostedZoneId,ParameterValue=$HOSTED_ZONE_ID"
-
-# If running in CI and not on the default branch, skip domain-related resources
-if [ -n "${SKIP_DOMAIN_SETUP:-}"  ]; then
-  PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=SkipDomainSetup,ParameterValue=$SKIP_DOMAIN_SETUP"
-fi
+PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=SetupDomains,ParameterValue=${SETUP_DOMAINS:-no}"
 
 sam deploy \
  --config-file $(pwd)/cloudformation/config.toml \

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -2,20 +2,43 @@
 
 set -euo pipefail
 
+get_hosted_zone_id () {
+  local hostname="$1"
+
+  # First, list all zones
+  # Then, return the Id of the zone that matches the hostname
+  # and finally, trim off the prefix since AWS seends back an Id field that's
+  # more than just the usable Id
+  aws route53 list-hosted-zones | jq -r ".HostedZones[] | select(.Name | contains(\"$hostname\")) | .Id" | awk -F/ '{print $NF}'
+}
+
 SHA="${BUILDKITE_COMMIT:-$(git rev-parse HEAD)}"
 
 STAGE_NAME="${STAGE_NAME:-development}"
+
+if [ -z "${CI:-}" ]; then
+  DOMAIN_NAME="${DOMAIN_NAME:playground.beacon.codelikeacarpenter.com}"
+  STACK_NAME="${STACK_NAME:-beacon}"
+fi
+
+ZONE_DOMAIN_NAME=${ZONE_DOMAIN_NAME:-$DOMAIN_NAME}
+
+HOSTED_ZONE_ID=$(get_hosted_zone_id "$ZONE_DOMAIN_NAME")
+
+if [ -z "$HOSTED_ZONE_ID" ]; then
+  echo "Could not find hosted zone for $ZONE_DOMAIN_NAME"
+  echo "DOMAIN_NAME: $DOMAIN_NAME"
+  echo "SHA: $SHA"
+  exit 1
+fi
 
 PARAMETER_OVERRIDES=''
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=StageName,ParameterValue=$STAGE_NAME"
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=SHA,ParameterValue=$SHA}"
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=XHoneycombTeam,ParameterValue=$X_HONEYCOMB_TEAM"
+PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=DomainName,ParameterValue=$DOMAIN_NAME"
+PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=HostedZoneId,ParameterValue=$HOSTED_ZONE_ID"
 
-set +u
-if [ -z "$CI" ]; then
-  STACK_NAME="${STACK_NAME:-beacon}"
-fi
-set -u
 
 sam deploy \
  --config-file $(pwd)/cloudformation/config.toml \

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -39,6 +39,10 @@ PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=XHoneycombTeam,ParameterV
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=DomainName,ParameterValue=$DOMAIN_NAME"
 PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=HostedZoneId,ParameterValue=$HOSTED_ZONE_ID"
 
+# If running in CI and not on the default branch, skip domain-related resources
+if [ -n "${SKIP_DOMAIN_SETUP:-}"  ]; then
+  PARAMETER_OVERRIDES="$PARAMETER_OVERRIDES ParameterKey=SkipDomainSetup,ParameterValue=$SKIP_DOMAIN_SETUP"
+fi
 
 sam deploy \
  --config-file $(pwd)/cloudformation/config.toml \


### PR DESCRIPTION
This got a little bigger than it was a originally supposed to be. The first four commits are cleanup and bug fixes w.r.t. the buildkite process. I moved nearly everyting in `.buildkite/utilities` into bash functions so that I didn't have to put all the functions first (functions in bash are not hoisted on the first pass, but are hoisted once you're inside a function scope). 

Then, I tried configuring DNS and the related certificates entirely within template.yml. Unfortunately, that ends up not working very well because the nameserver values exposed by the stack's zone need to be manually entered in the management account's zone, so there needs to be a manual intervention part way through the stack creation.

After that, I redesigned the DNS setup so that zone delegation is handled entirely outside of the stack. There's a comment block showing the terraform config that I used for that management.

I initially tried creating certificates and testing against real domains on each PR build, but the DNS and certification provision adds five to ten minutes to stack creation and twenty to thirty minutes to stack destruction, so I quickly disabled that behavior. 

Finally, now that production actually means something, I setup deploys for the production account.